### PR TITLE
adding in additional build step for jfrog build push and xray scan

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -150,12 +150,12 @@ steps:
           codefresh auth create-context --api-key ${{CODEFRESH_CLI_KEY}} &&
           jfrog rt build-publish --server-id=jfrogjd --build-url="${{CF_BUILD_URL}}" --env-exclude="*key*;*pass*;" ${{CF_REPO_NAME}} ${{CF_BUILD_ID}} |& tee publish.txt &&
           codefresh annotate image $$(docker images -q "${{REPOSITORY}}/swampup18/crochunter:${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}") 
-          --label ARTIFACTORY_BUILD_URL="$$(sed -n "s/^.*http/http/p" publish.txt)" &&
+          --label JFROG_ARTIFACTORY_BUILD_URL="$$(sed -n "s/^.*http/http/p" publish.txt)" &&
           jfrog rt build-scan --server-id=jfrogjd ${{CF_REPO_NAME}} ${{CF_BUILD_ID}} | tee results.json && 
           codefresh annotate image $$(docker images -q "${{REPOSITORY}}/swampup18/crochunter:${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}") 
-          --label XRAY_ALERTS="$$(jq ".summary.total_alerts" results.json)"
-          --label XRAY_MESSAGE="$$(jq ".summary.message" results.json)"
-          --label XRAY_DETAILS_URL="$$(jq ".summary.more_details_url" results.json)" && 
+          --label JFROG_XRAY_ALERTS="$$(jq ".summary.total_alerts" results.json)"
+          --label JFROG_XRAY_MESSAGE="$$(jq ".summary.message" results.json)"
+          --label JFROG_XRAY_DETAILS_URL="$$(jq ".summary.more_details_url" results.json)" && 
           if [[ "$$(jq ".summary.fail_build" results.json)" = *true* ]]; then exit 1; else exit 0; fi
           '
         depends_on:
@@ -169,9 +169,9 @@ steps:
       metadata:
         set:
           - '${{BuildingDockerImage.imageId}}':
-            - XRAY_SCAN: true
+            - JFROG_XRAY_SCAN: true
     on_fail:
       metadata:
         set:
           - '${{BuildingDockerImage.imageId}}':
-            - XRAY_SCAN: false
+            - JFROG_XRAY_SCAN: false

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -16,6 +16,10 @@ steps:
     image_name: swampup18/crochunter
     tag: '${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}'
     registry: jfrog-jd-art
+  PackageHelmChart:
+      image: devth/helm
+      commands:
+        - cf_export PACKAGE=$(helm package ./charts/croc-hunter | cut -d " " -f 8)
   Deploy_with_Helm:
     image: codefresh/cfstep-helm:2.9.0
     when:
@@ -47,7 +51,6 @@ steps:
       - custom_imagePullSecrets_email=${{REPO_EMAIL}}
       - custom_image=jfrogjd-crochunter.jfrog.io/swampup18/crochunter
       - custom_ingress_hostname=${{INGRESS_HOSTNAME}}
-
   BuildingTestDockerImage:
     title: Building Test Docker Image
     type: build
@@ -110,13 +113,65 @@ steps:
       metadata:
         set:
           - '${{BuildingTestDockerImage.imageId}}':
-              - SELENIUM_DVTS: true
+            - SELENIUM_DVTS: true
     on_fail:
       metadata:
         set:
           - '${{BuildingTestDockerImage.imageId}}':
-              - SELENIUM_DVTS: false
+            - SELENIUM_DVTS: false
     when:
       branch:
         only:
           - master
+  PushBuildInfoAndArtifactsToArtifactory:
+    title: Updating Artifactory with Codefresh Build Information and Artifacts
+    type: composition
+    composition:
+      version: '2'
+      services:
+        buildimage:
+          image: ${{BuildingDockerImage}}
+          command: sh -c "exit 0"
+    composition_candidates:
+      scan_service:
+        image: codefresh/docker-jfrog-cli-go:initial-branch-c6eeb5c
+        working_dir: ${{CF_VOLUME_PATH}}/${{CF_REPO_NAME}}
+        environment:
+          - JFROG_CLI_OFFER_CONFIG=false
+        command: >
+          bash -c '
+          docker login --username ${{REPO_USER}} --password "${{REPO_PASS}}" ${{REPOSITORY}} && 
+          jfrog rt build-collect-env ${{CF_REPO_NAME}} ${{CF_BUILD_ID}} && 
+          jfrog rt build-add-git ${{CF_REPO_NAME}} ${{CF_BUILD_ID}} && 
+          jfrog rt build-add-dependencies ${{CF_REPO_NAME}} ${{CF_BUILD_ID}} *report.html && 
+          jfrog rt config jfrogjd --url="https://jfrogjd.jfrog.io/jfrogjd" --user=${{REPO_USER}} --password="${{REPO_PASS}}" && 
+          jfrog rt docker-push --server-id=jfrogjd --build-name=${{CF_REPO_NAME}} --build-number=${{CF_BUILD_ID}} "${{REPOSITORY}}/swampup18/crochunter:${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}" crochunter && 
+          jfrog rt upload --server-id=jfrogjd --build-name=${{CF_REPO_NAME}} --build-number=${{CF_BUILD_ID}} "$PACKAGE" helm-repo && 
+          codefresh auth create-context --api-key ${{CODEFRESH_CLI_KEY}} &&
+          jfrog rt build-publish --server-id=jfrogjd --build-url="${{CF_BUILD_URL}}" --env-exclude="*key*;*pass*;" ${{CF_REPO_NAME}} ${{CF_BUILD_ID}} |& tee publish.txt &&
+          codefresh annotate image $$(docker images -q "${{REPOSITORY}}/swampup18/crochunter:${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}") 
+          --label ARTIFACTORY_BUILD_URL="$$(sed -n "s/^.*http/http/p" publish.txt)" &&
+          jfrog rt build-scan --server-id=jfrogjd ${{CF_REPO_NAME}} ${{CF_BUILD_ID}} | tee results.json && 
+          codefresh annotate image $$(docker images -q "${{REPOSITORY}}/swampup18/crochunter:${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}") 
+          --label XRAY_ALERTS="$$(jq ".summary.total_alerts" results.json)"
+          --label XRAY_MESSAGE="$$(jq ".summary.message" results.json)"
+          --label XRAY_DETAILS_URL="$$(jq ".summary.more_details_url" results.json)" && 
+          if [[ "$$(jq ".summary.fail_build" results.json)" = *true* ]]; then exit 1; else exit 0; fi
+          '
+        depends_on:
+          - buildimage
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+          - /var/lib/docker:/var/lib/docker
+          - '${{CF_VOLUME_NAME}}:/codefresh/volume'
+    add_flow_volume_to_composition: true
+    on_success:
+      metadata:
+        set:
+          - '${{BuildingDockerImage.imageId}}':
+            - XRAY_SCAN: true
+    on_fail:
+      metadata:
+        set:
+          - '${{BuildingDockerImage.imageId}}':
+            - XRAY_SCAN: false


### PR DESCRIPTION
@jldeen Please review.

This new build step will:
- Add the build to Artifactory including a URL back to Codefresh build page.  
- Add information from .git to the build including commit URL.
- Capture the Environment Variables used for the step excluding password and keys.
- Upload Docker image and Helm Chart to Artifactory and attach to the build in Artifactory.  
- Annotate the Docker image in Codefresh with Artifactory Build URL.
- Scan Artifactory build and artifacts with Xray.
- Return Scan Results.
- Annotate Codefresh Docker image with Xray Information.
- Fail the Codefresh build if Xray scan fails.

I'll put this into Python soon but for now this will show you the intended behavior of the final integration.

https://g.codefresh.io/images/1e24f868c28458ab2abbfb37ad1919c388058caf/summary