### PR TITLE
Fix the xray url

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -160,7 +160,7 @@ steps:
           codefresh annotate image $$(docker images -q "${{REPOSITORY}}/swampup18/crochunter:${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}") 
           --label JF_XRAY_ALERTS="$$(jq ".summary.total_alerts" results.json)"
           --label JF_XRAY_MSG="$$(jq ".summary.message" results.json)"
-          --label JF_XRAY_RPT="$$(jq ".summary.more_details_url" results.json)" && 
+          --label JF_XRAY_RPT="https://jfrogjd-xray.jfrog.io/web/#/component/details/docker:%252F%252Fswampup18%252Fcrochunter/${{CF_BRANCH_TAG_NORMALIZED}}-${{CF_SHORT_REVISION}}" && 
           if [[ "$$(jq ".summary.fail_build" results.json)" = *true* ]]; then exit 1; else exit 0; fi
           '
         depends_on:


### PR DESCRIPTION
The more info url in the json actually refers to the license, not to the xray scan. See this doc: https://www.jfrog.com/confluence/display/XRAY/Xray+REST+API#XrayRESTAPI-BuildSummary

But we can construct the url with the image tag.